### PR TITLE
Remove url prefix to fix mixed-content error

### DIFF
--- a/src/components/AnswerScreen.vue
+++ b/src/components/AnswerScreen.vue
@@ -148,7 +148,7 @@ export default {
 	},
 	methods: {
 		async getOmdb() {
-			let response = await fetch("http://www.omdbapi.com/?apikey=6fa0628f&i=" + this.currentQuestion.imdbId.split('?')[0])
+			let response = await fetch("//www.omdbapi.com/?apikey=6fa0628f&i=" + this.currentQuestion.imdbId.split('?')[0])
 			this.currentQuestion.omdb = await response.json()
 		},
 		nextQuestion() {


### PR DESCRIPTION
The answer page fails to load when [visiting the site over TLS](https://welldave.fun). Since the main page is loaded over TLS but the code has a hardcoded `http:` at the start of the API url, which is blocked due to [mixed content rules](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content).

Removing the http predicate from the url allows the browser to fallback onto the protocol used to visit the page, avoiding any mixed content issues. You could also force it to https but that seemed less elegant ;)

Thanks for making this great game!